### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 13), qtbase5-dev, libqcustomplot-dev
 Standards-Version: 4.5.1
 Homepage: https://github.com/cunctator/traceshark
 Vcs-Browser: https://github.com/sudipm-mukherjee/traceshark.git
-Vcs-Git: https://github.com/sudipm-mukherjee/traceshark
+Vcs-Git: https://github.com/sudipm-mukherjee/traceshark.git
 
 Package: traceshark
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Sudip Mukherjee <sudipm.mukherjee@gmail.com>
 Build-Depends: debhelper-compat (= 13), qtbase5-dev, libqcustomplot-dev
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Homepage: https://github.com/cunctator/traceshark
 Vcs-Browser: https://github.com/sudipm-mukherjee/traceshark.git
 Vcs-Git: https://github.com/sudipm-mukherjee/traceshark.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/cunctator/traceshark/issues
+Bug-Submit: https://github.com/cunctator/traceshark/issues/new
+Repository-Browse: https://github.com/cunctator/traceshark


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/traceshark/5f11bc28-7e08-457b-904f-311c31d57d47.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/5f11bc28-7e08-457b-904f-311c31d57d47/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5f11bc28-7e08-457b-904f-311c31d57d47/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5f11bc28-7e08-457b-904f-311c31d57d47/diffoscope)).
